### PR TITLE
[697-minLength-with-nullable] Consider nullable property for minLengt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [Jane] [GH#748](https://github.com/janephp/janephp/pull/748) Move PHP CS Fixer to a separate composer.json file
 - [JsonSchema] [GH#747](https://github.com/janephp/janephp/pull/747) Allow league/uri v7
+- [JsonSchema] [GH#698](https://github.com/janephp/janephp/pull/698) Consider nullable property for minLengthValidator
 - [OpenApiCommon] [GH#750](https://github.com/janephp/janephp/pull/750) Replace 'findUrlFactory' with 'findUriFactory'
 
 ## [7.5.3] - 2023-08-04

--- a/src/Component/JsonSchema/Guesser/Validator/String_/MinLengthValidator.php
+++ b/src/Component/JsonSchema/Guesser/Validator/String_/MinLengthValidator.php
@@ -31,7 +31,28 @@ class MinLengthValidator implements ValidatorInterface
             'minMessage' => 'This value is too short. It should have {{ limit }} characters or more.',
         ]));
         if ($object->getMinLength() > 0) {
-            $guess->addValidatorGuess(new ValidatorGuess(NotBlank::class));
+            $nullable = false;
+
+            if (\get_class($object) === JsonSchema::class) {
+                $nullable = \is_array($object->getType()) ? \in_array('null', $object->getType()) : 'null' === $object->getType();
+            }
+            if (\get_class($object) === 'Jane\\Component\\OpenApi2\\JsonSchema\\Model\\Schema') {
+                $nullable = $object->offsetExists('x-nullable') && \is_bool($object->offsetGet('x-nullable')) && $object->offsetGet('x-nullable');
+            }
+            if (\get_class($object) === 'Jane\\Component\\OpenApi3\\JsonSchema\\Model\\Schema') {
+                $nullable = method_exists($object, 'getNullable') && $object->getNullable() ?? false;
+            }
+
+            $options = [];
+            if ($nullable === true) {
+                // Using an integer as a replacement boolean value is most likely to break as soon as
+                // \Symfony\Component\Validator\Constraints\NotBlank::$allowNull is strongly typed.
+                // Currently we can not use 'bool' here, because \Jane\Component\JsonSchema\Generator\ValidatorGenerator::generateConstraint()
+                // does not handle them. This seems to be an issue with nikic/php-parser not being able to provide support
+                // for it.
+                $options = ['allowNull' => 1];
+            }
+            $guess->addValidatorGuess(new ValidatorGuess(NotBlank::class, $options));
         }
     }
 }

--- a/src/Component/JsonSchema/Tests/Validation/schema.json
+++ b/src/Component/JsonSchema/Tests/Validation/schema.json
@@ -224,6 +224,18 @@
                     "pattern": "^[a-z]+$"
                 }
             }
+        },
+        "VerifyNullableStringPropertyWithMinLengthValidatesCorrectly":{
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "minLength": 1
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
…hValidator.

Use integer so the option value 'allowNull' is actually generated into the client.